### PR TITLE
add services page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ data/
 # Obsidian files
 packages/obs-site/.obsidian/workspace.json
 packages/obs-site/.obsidian/themes
+
+# Claude Code
+.claude/

--- a/packages/obs-site/🎸 services.md
+++ b/packages/obs-site/🎸 services.md
@@ -1,0 +1,19 @@
+---
+created: 1777766400
+lastTouched: 1777766400
+---
+## services
+
+A few things I offer outside of my day job. The easiest way to reach me is `info(at)spellpierce(dot)com`.
+
+### music production
+
+I produce, record, and mix music — mostly under my own projects like [[_spell_pierce|Spell Pierce]], but I'm open to producing or co-producing for other artists. Happy to work remotely or in person in NYC.
+
+### software consulting
+
+I've spent over a decade building web platforms, developer tools, and ML-adjacent products at places like Spotify, Grubhub, and Vice. I take on a small number of consulting engagements per year — usually around frontend architecture, TypeScript-heavy codebases, or technical strategy for early-stage teams.
+
+### studio performer
+
+I play guitar, keyboard, and drums, and I'm available for session/studio work — in person around NYC or remotely with high-quality tracked stems.

--- a/packages/obs-static-site/nav.json
+++ b/packages/obs-static-site/nav.json
@@ -1,1 +1,1 @@
-["👋 hello.md", "⏱️ lately.md", "💡about.md", "👷‍♂️ projects.md", "tags"]
+["👋 hello.md", "⏱️ lately.md", "💡about.md", "👷‍♂️ projects.md", "🎸 services.md", "tags"]


### PR DESCRIPTION
## Summary
- New top-level page `🎸 services.md` covering music production, software consulting, and studio performer (guitar/keyboard/drums) work
- Added to site nav after projects
- Added `.claude/` to `.gitignore`

Contact line uses obfuscated form (`info(at)spellpierce(dot)com`) so crawlers don't pick it up.

## Test plan
- [x] Verified locally with `make watch`: page renders at `/🎸-services.html`, appears in nav
- [x] Frontmatter (`created`/`lastTouched`) matches existing top-level pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)