### PR TITLE
Remove Ko-fi button from sidebar footer

### DIFF
--- a/packages/obs-static-site/build.js
+++ b/packages/obs-static-site/build.js
@@ -585,7 +585,6 @@ function renderPage(title, mainContent, pageSlug, graphData, metadata = {}) {
       <footer class="sidebar-footer">
         <div class="sidebar-icons">
           <a href="https://github.com/omardelarosa/website" class="github-link" target="_blank" rel="noopener noreferrer" aria-label="View source on GitHub"><svg class="github-icon" width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>
-          <a href='https://ko-fi.com/K3K51SJIVR' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
         </div>
         <span class="sidebar-copyright">&copy; ${new Date().getFullYear()} omar delarosa</span>
       </footer>

--- a/packages/obs-static-site/build.test.js
+++ b/packages/obs-static-site/build.test.js
@@ -260,12 +260,6 @@ tests.push(() => runTest('renderPage: includes stylesheets', () => {
   assertIncludes(result, '<link rel="stylesheet" href="/highlight.css">');
 }));
 
-tests.push(() => runTest('renderPage: includes Ko-fi widget', () => {
-  const result = renderPage('Test Title', '<p>Content</p>', 'test-slug', null);
-  assertIncludes(result, 'kofiwidget2.init');
-  assertIncludes(result, 'omar delarosa');
-}));
-
 tests.push(() => runTest('renderPage: includes file tree script', () => {
   const result = renderPage('Test Title', '<p>Content</p>', 'test-slug', null);
   assertIncludes(result, 'window.__FILE_TREE__');


### PR DESCRIPTION
## Summary
- Remove the Ko-fi "Buy Me a Coffee" link/image from the obs-static-site sidebar footer (`packages/obs-static-site/build.js`).
- Drop the now-obsolete `renderPage: includes Ko-fi widget` test in `build.test.js`.

## Test plan
- [x] `make test` — 46/46 passing
- [ ] Spot-check the rendered sidebar footer locally (`make serve`) shows only the GitHub icon and copyright

🤖 Generated with [Claude Code](https://claude.com/claude-code)